### PR TITLE
Link LLVM initialization functions

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -57,6 +57,19 @@ mod llvm {
         "execution_engine.rs",
     ];
 
+    const INIT_MACROS: &[&str] = &[
+        "LLVM_InitializeAllTargetInfos",
+        "LLVM_InitializeAllTargets",
+        "LLVM_InitializeAllTargetMCs",
+        "LLVM_InitializeAllAsmPrinters",
+        "LLVM_InitializeAllAsmParsers",
+        "LLVM_InitializeAllDisassemblers",
+        "LLVM_InitializeNativeTarget",
+        "LLVM_InitializeNativeAsmParser",
+        "LLVM_InitializeNativeAsmPrinter",
+        "LLVM_InitializeNativeDisassembler",
+    ];
+
     #[derive(Default)]
     pub struct Generator {
         declarations: Vec<Declaration>,
@@ -80,6 +93,11 @@ mod llvm {
             let mut file = File::create(path)?;
 
             for decl in self.declarations {
+                if INIT_MACROS.contains(&decl.name.as_str()) {
+                    // Skip target initialization wrappers
+                    // (see llvm-sys/wrappers/target.c)
+                    continue;
+                }
                 writeln!(
                     file,
                     "create_proxy!({}; {}; {});",

--- a/src/init.rs
+++ b/src/init.rs
@@ -1,0 +1,29 @@
+
+use super::SHARED_LIB;
+
+const POSSIBLE_BACKENDS: &[&str] = &[
+    "AArch64",
+    "AMDGPU",
+    "ARM",
+    "BPF",
+    "Hexagon",
+    "Lanai",
+    "Mips",
+    "MSP430",
+    "NVPTX",
+    "PowerPC",
+    "Sparc",
+    "SystemZ",
+    "X86",
+    "XCore",
+];
+
+#[no_mangle]
+pub unsafe extern "C" fn LLVM_InitializeAllTargets() {
+    for backend in POSSIBLE_BACKENDS {
+        let name = format!("LLVMInitialize{}Target", backend);
+        if let Ok(entrypoint) = SHARED_LIB.get::<unsafe extern "C" fn()>(name.as_bytes()) {
+            entrypoint();
+        }
+    }
+}

--- a/src/init.rs
+++ b/src/init.rs
@@ -1,22 +1,38 @@
-
 use super::SHARED_LIB;
 
+use std::io::{BufRead, BufReader, Result};
+use std::process::Command;
+
 const POSSIBLE_BACKENDS: &[&str] = &[
-    "AArch64",
-    "AMDGPU",
-    "ARM",
-    "BPF",
-    "Hexagon",
-    "Lanai",
-    "Mips",
-    "MSP430",
-    "NVPTX",
-    "PowerPC",
-    "Sparc",
-    "SystemZ",
-    "X86",
-    "XCore",
+    "AArch64", "AMDGPU", "ARM", "BPF", "Hexagon", "Lanai", "Mips", "MSP430", "NVPTX", "PowerPC",
+    "Sparc", "SystemZ", "X86", "XCore",
 ];
+
+fn get_native_arch() -> Result<String> {
+    let output = Command::new("rustc").args(&["--print", "cfg"]).output()?;
+    let buf = BufReader::new(output.stdout.as_slice());
+    for line in buf.lines() {
+        let line = line?;
+        if !line.starts_with("target_arch") {
+            continue;
+        }
+        // line should be like: target_arch="x86_64"
+        return Ok(line.split('"').nth(1).unwrap().into());
+    }
+    unreachable!("`rustc --print cfg` result is wrong");
+}
+
+fn arch2backend(arch: &str) -> String {
+    match arch {
+        "x86_64" => "X86".into(),
+        _ => panic!("Unknown backend: {}", arch), // FIXME
+    }
+}
+
+fn get_native_backend() -> String {
+    let arch = get_native_arch().expect("Fail to get native arch");
+    arch2backend(&arch)
+}
 
 #[no_mangle]
 pub unsafe extern "C" fn LLVM_InitializeAllTargets() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,8 @@ use lib::Library;
 mod path;
 use path::find_lib_path;
 
+pub mod init;
+
 lazy_static! {
     static ref SHARED_LIB: Library = {
         let lib_path = match find_lib_path() {


### PR DESCRIPTION
rustc-llvm-proxy cannot link `llvm_sys::target::LLVM_InitializeAllTargets` and other initialization function listed at https://github.com/tari/llvm-sys.rs/blob/36cdcf413a0f452ffb0c7c7ba7dd5954b0a59214/src/target.rs#L169.

LLVM C API defines [initialization APIs](http://llvm.org/doxygen/group__LLVMCTarget.html) as , e.g. `LLVMInitializeAllTargets` as `static inline` functions, and these symbols does not exist in the shared library. [llvm-sys/wrapper/target.c](https://github.com/tari/llvm-sys.rs/blob/master/wrappers/target.c) create public ABI of these functions to call from Rust. However, this way cannot be used with this crate because it needs to compile C code (target.c) with the LLVM library.

I re-implement these as rust code.