### PR TITLE
Update llvm-sys and cargo_metadata.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,10 @@ libloading = "0.5"
 lazy_static = "1.0"
 failure = "0.1"
 libc = "0.2"
-llvm-sys = { version = "70", features = ["no-llvm-linking", "disable-alltargets-init"] }
+llvm-sys = { version = "80", features = ["no-llvm-linking", "disable-alltargets-init"] }
 
 [build-dependencies]
-cargo_metadata = "0.6"
+cargo_metadata = "0.8"
 failure = "0.1"
 quote = "0.6"
 syn = { version = "0.15", features = ["full"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,7 @@ pub mod proxy {
     use llvm_sys::debuginfo::*;
     use llvm_sys::execution_engine::*;
     use llvm_sys::disassembler::*;
+    use llvm_sys::error::*;
     use llvm_sys::error_handling::*;
     use llvm_sys::link_time_optimizer::*;
     use llvm_sys::lto::*;


### PR DESCRIPTION
rustc seems to be using llvm 8

```
rustc 1.35.0 (3c235d560 2019-05-20)
binary: rustc
commit-hash: 3c235d5600393dfe6c36eeed34042efad8d4f26e
commit-date: 2019-05-20
host: x86_64-unknown-linux-gnu
release: 1.35.0
LLVM version: 8.0
```

and i was getting build errors with cargo_metadata so I updated that too

```
error: proc-macro derive panicked
   --> /home/devel/.cargo/registry/src/github.com-1ecc6299db9ec823/cargo_metadata-0.6.0/src/lib.rs:224:35
    |
224 | #[derive(Clone, Debug, Serialize, Deserialize)]
    |                                   ^^^^^^^^^^^
    |
    = help: message: unknown serde container attribute `transparent`
```
