### PR TITLE
Fix create_proxy! macro

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -118,7 +118,9 @@ mod llvm {
                 writeln!(
                     file,
                     "create_proxy!({}; {}; {});",
-                    decl.name, decl.ret_ty, decl.args
+                    decl.name,
+                    decl.ret_ty,
+                    decl.args.trim_end_matches(",")
                 )?;
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,10 +76,10 @@ pub mod proxy {
 
     use llvm_sys::analysis::*;
     use llvm_sys::debuginfo::*;
-    use llvm_sys::execution_engine::*;
     use llvm_sys::disassembler::*;
     use llvm_sys::error::*;
     use llvm_sys::error_handling::*;
+    use llvm_sys::execution_engine::*;
     use llvm_sys::link_time_optimizer::*;
     use llvm_sys::lto::*;
     use llvm_sys::object::*;

--- a/src/path.rs
+++ b/src/path.rs
@@ -89,7 +89,8 @@ fn collect_possible_paths() -> Result<Vec<PathBuf>, Error> {
         cargo_path.pop();
 
         if let Some(toolchain) = cargo_path.file_name() {
-            let arch = env::var("HOST").unwrap_or_else(|_| extract_arch(toolchain.to_str().unwrap()));
+            let arch =
+                env::var("HOST").unwrap_or_else(|_| extract_arch(toolchain.to_str().unwrap()));
 
             paths.push(
                 cargo_path


### PR DESCRIPTION
```
error: unexpected end of macro invocation
  --> /home/travis/build/denzp/rustc-llvm-proxy/target/debug/build/rustc-llvm-proxy-8a4ff3d82bd298fa/out/llvm_gen.rs:6:152
   |
6  | create_proxy!(LLVMContextSetDiagnosticHandler; (); C : LLVMContextRef , Handler : LLVMDiagnosticHandler , DiagnosticContext : * mut :: libc :: c_void ,);
   |                                                                                                                                                        ^ missing tokens in macro arguments
   | 
  ::: src/lib.rs:93:5
   |
93 |     macro_rules! create_proxy {
   |     ------------------------- when calling this macro
```

https://travis-ci.org/denzp/rustc-llvm-proxy/jobs/625547316

This patch fix it by removing `,` at the end