### PR TITLE
Fixed LLVM path search

### DIFF
--- a/src/path.rs
+++ b/src/path.rs
@@ -61,7 +61,7 @@ fn find_library_in_directory(directory: &Path) -> Option<PathBuf> {
     match read_dir(directory) {
         Ok(files) => files
             .filter_map(Result::ok)
-            .find(|file| file.file_name().to_string_lossy().starts_with("libLLVM"))
+            .find(|file| file.file_name().to_string_lossy().starts_with("libLLVM."))
             .map(|file| file.path()),
 
         Err(_) => None,


### PR DESCRIPTION
While searching for LLVM, we might encounter other LLVM libraries (eg. if LLVM was compiled to a static library, `libLLVMAnalysis.a`, etc.), which will then be wrongly returned.

This patch makes sure we only take the top-level library.