### PR TITLE
Update to LLVM 11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ libloading = "0.5"
 lazy_static = "1.0"
 failure = "0.1"
 libc = "0.2"
-llvm-sys = { version = "80", features = ["no-llvm-linking", "disable-alltargets-init"] }
+llvm-sys = { version = "110", features = ["no-llvm-linking", "disable-alltargets-init"] }
 
 [build-dependencies]
 cargo_metadata = "0.8"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![deny(warnings)]
-#![allow(non_snake_case, unused_imports, unused_macros)]
+#![allow(non_snake_case, unused_imports, unused_macros, deprecated)]
 
 //! Dynamically proxy LLVM calls into Rust own shared library! 🎉
 //!


### PR DESCRIPTION
As per subject, this bumps the dependency to llvm-sys = 110. It also allows deprecated warnings otherwise the build fails generating wrappers for deprecated llvm-sys symbols.